### PR TITLE
Optimize ad-hoc queries to use 'in' operator #Closes 25

### DIFF
--- a/controls/private_repo.sp
+++ b/controls/private_repo.sp
@@ -101,7 +101,7 @@ control "private_repo_default_branch_blocks_force_push" {
       github_my_repository as r
       left join github_branch_protection as b on r.full_name = b.repository_full_name
     where
-      visibility = 'private' and r.fork = ${local.include_forks} and (b.name = 'main' or b.name = 'master')
+      visibility = 'private' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
   EOT
 }
 
@@ -127,7 +127,7 @@ control "private_repo_default_branch_blocks_deletion" {
       github_my_repository as r
       left join github_branch_protection as b on r.full_name = b.repository_full_name
     where
-      visibility = 'private' and r.fork = ${local.include_forks} and (b.name = 'main' or b.name = 'master')
+      visibility = 'private' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
   EOT
 }
 
@@ -153,7 +153,7 @@ control "private_repo_default_branch_protections_apply_to_admins" {
       github_my_repository as r
       left join github_branch_protection as b on r.full_name = b.repository_full_name
     where
-      visibility = 'private' and r.fork = ${local.include_forks} and (b.name = 'main' or b.name = 'master')
+      visibility = 'private' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
   EOT
 }
 
@@ -173,6 +173,6 @@ control "private_repo_default_branch_requires_pull_request_reviews" {
       github_my_repository as r
       left join github_branch_protection as b on r.full_name = b.repository_full_name
     where
-      visibility = 'private' and r.fork = ${local.include_forks} and (b.name = 'main' or b.name = 'master')
+      visibility = 'private' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
   EOT
 }

--- a/controls/public_repo.sp
+++ b/controls/public_repo.sp
@@ -234,7 +234,7 @@ control "public_repo_default_branch_blocks_force_push" {
       github_my_repository as r
       left join github_branch_protection as b on r.full_name = b.repository_full_name
     where
-      visibility = 'public' and r.fork = ${local.include_forks} and (b.name = 'main' or b.name = 'master')
+      visibility = 'public' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
   EOT
 }
 
@@ -260,7 +260,7 @@ control "public_repo_default_branch_blocks_deletion" {
       github_my_repository as r
       left join github_branch_protection as b on r.full_name = b.repository_full_name
     where
-      visibility = 'public' and r.fork = ${local.include_forks} and (b.name = 'main' or b.name = 'master')
+      visibility = 'public' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
   EOT
 }
 
@@ -286,7 +286,7 @@ control "public_repo_default_branch_protections_apply_to_admins" {
       github_my_repository as r
       left join github_branch_protection as b on r.full_name = b.repository_full_name
     where
-      visibility = 'public' and r.fork = ${local.include_forks} and (b.name = 'main' or b.name = 'master')
+      visibility = 'public' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
   EOT
 }
 
@@ -306,6 +306,6 @@ control "public_repo_default_branch_requires_pull_request_reviews" {
       github_my_repository as r
       left join github_branch_protection as b on r.full_name = b.repository_full_name
     where
-      visibility = 'public' and r.fork = ${local.include_forks} and (b.name = 'main' or b.name = 'master')
+      visibility = 'public' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
   EOT
 }


### PR DESCRIPTION
# Result
```
> select
      r.full_name as resource,
      case
        when b.allow_force_pushes_enabled = 'false' then 'ok'
        else 'alarm'
      end as status,
      r.full_name || ' default branch ' || b.name ||
        case
          when b.allow_force_pushes_enabled = 'false' then ' prevents force push.'
          when b.allow_force_pushes_enabled = 'true' then ' allows force push.'
          -- If not false or true, then null, which means no branch protection rule exists
          else ' is not protected.'
        end as reason,
      r.full_name
    from
      github_my_repository as r
      left join github_branch_protection as b on r.full_name = b.repository_full_name
    where
      visibility = 'public' and r.fork = false and b.name in ('main', 'master')
+---------------------------+--------+------------------------------------------------------------------+---------------------------+
| resource                  | status | reason                                                           | full_name                 |
+---------------------------+--------+------------------------------------------------------------------+---------------------------+
| bigdatasourav/turbot-test | alarm  | bigdatasourav/turbot-test default branch main allows force push. | bigdatasourav/turbot-test |
+---------------------------+--------+------------------------------------------------------------------+---------------------------+
```
