### PR TITLE
Fix how the default branch protection is fetched

### DIFF
--- a/controls/private_repo.sp
+++ b/controls/private_repo.sp
@@ -109,9 +109,9 @@ control "private_repo_default_branch_blocks_force_push" {
       r.full_name
     from
       github_my_repository as r
-      left join github_branch_protection as b on r.full_name = b.repository_full_name
+      left join github_branch_protection as b on r.full_name = b.repository_full_name and r.default_branch = b.name
     where
-      visibility = 'private' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
+      visibility = 'private' and r.fork = ${local.include_forks}
   EOT
 }
 
@@ -135,9 +135,9 @@ control "private_repo_default_branch_blocks_deletion" {
       r.full_name
     from
       github_my_repository as r
-      left join github_branch_protection as b on r.full_name = b.repository_full_name
+      left join github_branch_protection as b on r.full_name = b.repository_full_name and r.default_branch = b.name
     where
-      visibility = 'private' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
+      visibility = 'private' and r.fork = ${local.include_forks}
   EOT
 }
 
@@ -162,9 +162,9 @@ control "private_repo_default_branch_protections_apply_to_admins" {
       r.full_name
     from
       github_my_repository as r
-      left join github_branch_protection as b on r.full_name = b.repository_full_name
+      left join github_branch_protection as b on r.full_name = b.repository_full_name and r.default_branch = b.name
     where
-      visibility = 'private' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
+      visibility = 'private' and r.fork = ${local.include_forks}
   EOT
 }
 
@@ -183,8 +183,8 @@ control "private_repo_default_branch_requires_pull_request_reviews" {
       r.full_name
     from
       github_my_repository as r
-      left join github_branch_protection as b on r.full_name = b.repository_full_name
+      left join github_branch_protection as b on r.full_name = b.repository_full_name and r.default_branch = b.name
     where
-      visibility = 'private' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
+      visibility = 'private' and r.fork = ${local.include_forks}
   EOT
 }

--- a/controls/private_repo.sp
+++ b/controls/private_repo.sp
@@ -99,7 +99,7 @@ control "private_repo_default_branch_blocks_force_push" {
         when b.allow_force_pushes_enabled = 'false' then 'ok'
         else 'alarm'
       end as status,
-      r.full_name || ' default branch ' || b.name ||
+      r.full_name || ' default branch ' || r.default_branch ||
         case
           when b.allow_force_pushes_enabled = 'false' then ' prevents force push.'
           when b.allow_force_pushes_enabled = 'true' then ' allows force push.'
@@ -125,7 +125,7 @@ control "private_repo_default_branch_blocks_deletion" {
         when b.allow_deletions_enabled = 'false' then 'ok'
         else 'alarm'
       end as status,
-      r.full_name || ' default branch ' || b.name ||
+      r.full_name || ' default branch ' || r.default_branch ||
         case
           when b.allow_deletions_enabled = 'false' then ' prevents deletion.'
           when b.allow_deletions_enabled = 'true' then ' allows deletion.'
@@ -152,7 +152,7 @@ control "private_repo_default_branch_protections_apply_to_admins" {
         when b.enforce_admins_enabled = 'true' then 'ok'
         else 'alarm'
       end as status,
-      r.full_name || ' default branch ' || b.name ||
+      r.full_name || ' default branch ' || r.default_branch ||
         case
           when b.enforce_admins_enabled = 'true' then ' protections apply to admins.'
           when b.enforce_admins_enabled = 'false' then ' protections do not apply to admins.'
@@ -179,7 +179,7 @@ control "private_repo_default_branch_requires_pull_request_reviews" {
         when b.required_pull_request_reviews is not null then 'ok'
         else 'alarm'
       end as status,
-      r.full_name || ' default branch ' || b.name || case when(b.required_pull_request_reviews is not null) then ' requires ' else ' does not require ' end || 'pull request reviews.' as reason,
+      r.full_name || ' default branch ' || r.default_branch || case when(b.required_pull_request_reviews is not null) then ' requires ' else ' does not require ' end || 'pull request reviews.' as reason,
       r.full_name
     from
       github_my_repository as r

--- a/controls/public_repo.sp
+++ b/controls/public_repo.sp
@@ -253,9 +253,9 @@ control "public_repo_default_branch_blocks_force_push" {
       r.full_name
     from
       github_my_repository as r
-      left join github_branch_protection as b on r.full_name = b.repository_full_name
+      left join github_branch_protection as b on r.full_name = b.repository_full_name and r.default_branch = b.name
     where
-      visibility = 'public' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
+      visibility = 'public' and r.fork = ${local.include_forks}
   EOT
 }
 
@@ -280,9 +280,9 @@ control "public_repo_default_branch_blocks_deletion" {
       r.full_name
     from
       github_my_repository as r
-      left join github_branch_protection as b on r.full_name = b.repository_full_name
+      left join github_branch_protection as b on r.full_name = b.repository_full_name and r.default_branch = b.name
     where
-      visibility = 'public' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
+      visibility = 'public' and r.fork = ${local.include_forks}
   EOT
 }
 
@@ -307,9 +307,9 @@ control "public_repo_default_branch_protections_apply_to_admins" {
       r.full_name
     from
       github_my_repository as r
-      left join github_branch_protection as b on r.full_name = b.repository_full_name
+      left join github_branch_protection as b on r.full_name = b.repository_full_name and r.default_branch = b.name
     where
-      visibility = 'public' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
+      visibility = 'public' and r.fork = ${local.include_forks}
   EOT
 }
 
@@ -328,8 +328,8 @@ control "public_repo_default_branch_requires_pull_request_reviews" {
       r.full_name
     from
       github_my_repository as r
-      left join github_branch_protection as b on r.full_name = b.repository_full_name
+      left join github_branch_protection as b on r.full_name = b.repository_full_name and r.default_branch = b.name
     where
-      visibility = 'public' and r.fork = ${local.include_forks} and b.name in ('main', 'master')
+      visibility = 'public' and r.fork = ${local.include_forks}
   EOT
 }

--- a/controls/public_repo.sp
+++ b/controls/public_repo.sp
@@ -243,7 +243,7 @@ control "public_repo_default_branch_blocks_force_push" {
         when b.allow_force_pushes_enabled = 'false' then 'ok'
         else 'alarm'
       end as status,
-      r.full_name || ' default branch ' || b.name ||
+      r.full_name || ' default branch ' || r.default_branch ||
         case
           when b.allow_force_pushes_enabled = 'false' then ' prevents force push.'
           when b.allow_force_pushes_enabled = 'true' then ' allows force push.'
@@ -270,7 +270,7 @@ control "public_repo_default_branch_blocks_deletion" {
         when b.allow_deletions_enabled = 'false' then 'ok'
         else 'alarm'
       end as status,
-      r.full_name || ' default branch ' || b.name ||
+      r.full_name || ' default branch ' || r.default_branch ||
         case
           when b.allow_deletions_enabled = 'false' then ' prevents deletion.'
           when b.allow_deletions_enabled = 'true' then ' allows deletion.'
@@ -297,7 +297,7 @@ control "public_repo_default_branch_protections_apply_to_admins" {
         when b.enforce_admins_enabled = 'true' then 'ok'
         else 'alarm'
       end as status,
-      r.full_name || ' default branch ' || b.name ||
+      r.full_name || ' default branch ' || r.default_branch ||
         case
           when b.enforce_admins_enabled = 'true' then ' protections apply to admins.'
           when b.enforce_admins_enabled = 'false' then ' protections do not apply to admins.'
@@ -324,7 +324,7 @@ control "public_repo_default_branch_requires_pull_request_reviews" {
         when b.required_pull_request_reviews is not null then 'ok'
         else 'alarm'
       end as status,
-      r.full_name || ' default branch ' || b.name || case when(b.required_pull_request_reviews is not null) then ' requires ' else ' does not require ' end || 'pull request reviews.' as reason,
+      r.full_name || ' default branch ' || r.default_branch || case when(b.required_pull_request_reviews is not null) then ' requires ' else ' does not require ' end || 'pull request reviews.' as reason,
       r.full_name
     from
       github_my_repository as r


### PR DESCRIPTION
Queries that fetched the default branch protection only match `main` or `master` branches. But the default branch could be anything. 
It now use the `default_branch` column from the repository.

Also the reason was buggy when there no default branch protection. It also use the `default_branch` now.